### PR TITLE
fix for max_keys kwarg in s3_bucket_filter function

### DIFF
--- a/simple_AWS/s3_functions.py
+++ b/simple_AWS/s3_functions.py
@@ -57,7 +57,7 @@ class S3Simple(object):
         """
         List contents of bucket with a filter
         """
-        if 'max-keys' in kwargs.keys():
+        if 'max_keys' in kwargs.keys():
             max_keys = kwargs['max_keys']
         else:
             max_keys = 1000 #S3 API default


### PR DESCRIPTION
in the s3_bucket_filter function the max_keys parameter does not work correctly, because different name is used when scanning kwargs:

```python
        if 'max-keys' in kwargs.keys():
            max_keys = kwargs['max_keys']
        else:
            max_keys = 1000 #S3 API default
```